### PR TITLE
Update CondaPkg.toml

### DIFF
--- a/CondaPkg.toml
+++ b/CondaPkg.toml
@@ -1,4 +1,4 @@
-channels = ["torch", "pytorch", "conda-forge"]
+channels = ["pytorch", "conda-forge"]
 
 [deps]
 numpy = ""

--- a/CondaPkg.toml
+++ b/CondaPkg.toml
@@ -1,3 +1,5 @@
+channels = ["torch", "pytorch", "conda-forge"]
+
 [deps]
 numpy = ""
 pytorch = ""


### PR DESCRIPTION
Small fix to ensure the PyTorch dependency loads properly when using `PythonCallExt`